### PR TITLE
엔디안 관련 처리 변경

### DIFF
--- a/src/BytePacketSupport/Converter/ByteConverter.cs
+++ b/src/BytePacketSupport/Converter/ByteConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -9,62 +10,62 @@ namespace BytePacketSupport.Converter
     {
         public static byte[] GetBytes(string asciiByte)=> Encoding.ASCII.GetBytes (asciiByte);
 
-        public static byte[] GetBytes(int intByte, bool isLittleEndian = true)
+        public static byte[] GetBytes(int intByte, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (intByte);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
 
-        public static byte[] GetBytes(long longBytes, bool isLittleEndian = true)
+        public static byte[] GetBytes(long longBytes, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (longBytes);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
-        public static byte[] GetBytes(short shortByte, bool isLittleEndian = true)
+        public static byte[] GetBytes(short shortByte, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (shortByte);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
 
-        public static byte[] GetBytes(uint uintByte, bool isLittleEndian = true)
+        public static byte[] GetBytes(uint uintByte, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (uintByte);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
 
-        public static byte[] GetBytes(ulong ulongBytes, bool isLittleEndian = true)
+        public static byte[] GetBytes(ulong ulongBytes, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (ulongBytes);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
-        public static byte[] GetBytes(ushort ushortByte, bool isLittleEndian = true)
+        public static byte[] GetBytes(ushort ushortByte, bool isMustReverseUnit = false)
         {
             byte[] bytes = BitConverter.GetBytes (ushortByte);
 
-            if (BitConverter.IsLittleEndian == isLittleEndian)
-                return bytes;
+            if (isMustReverseUnit == true)
+                Array.Reverse(bytes);
 
-            return bytes.Reverse ().ToArray ();
+            return bytes;
         }
     }
 }

--- a/src/BytePacketSupport/PacketBuilder.Append.cs
+++ b/src/BytePacketSupport/PacketBuilder.Append.cs
@@ -34,42 +34,42 @@ namespace BytePacketSupport
 
         public PacketBuilder @int(int intByte)
         {
-            byte[] datas = ByteConverter.GetBytes (intByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (intByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }
 
         public PacketBuilder @long(long longByte)
         {
-            byte[] datas = ByteConverter.GetBytes (longByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (longByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }
 
         public PacketBuilder @short(short shortByte)
         {
-            byte[] datas = ByteConverter.GetBytes (shortByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (shortByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }
 
         public PacketBuilder @uint(uint uintByte)
         {
-            byte[] datas = ByteConverter.GetBytes (uintByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (uintByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }
 
         public PacketBuilder @ulong (ulong ulongByte)
         {
-            byte[] datas = ByteConverter.GetBytes (ulongByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (ulongByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }
 
         public PacketBuilder @ushort (ushort ushortByte)
         {
-            byte[] datas = ByteConverter.GetBytes (ushortByte, isLittleEnidan);
+            byte[] datas = ByteConverter.GetBytes (ushortByte, isMustReverseUnit);
             packetData.AddRange (datas);
             return this;
         }

--- a/src/BytePacketSupport/PacketBuilder._.cs
+++ b/src/BytePacketSupport/PacketBuilder._.cs
@@ -8,18 +8,20 @@ namespace BytePacketSupport
         private readonly PacketBuilderConfiguration _configuration;
         private List<byte> packetData = new List<byte> ();
 
-        private bool isLittleEnidan = true; 
+        private readonly bool isMustReverseUnit;
         public PacketBuilder()
         {
             this._configuration = new PacketBuilderConfiguration ();
 
-            isLittleEnidan = BitConverter.IsLittleEndian;
+            isMustReverseUnit = (BitConverter.IsLittleEndian == true && this._configuration.DefaultEndian == Enums.Endian.BIG) ||
+                                (BitConverter.IsLittleEndian == false && this._configuration.DefaultEndian == Enums.Endian.LITTLE);
         }
-        public PacketBuilder(PacketBuilderConfiguration? configuration)
+        public PacketBuilder(PacketBuilderConfiguration configuration)
         {
             this._configuration = configuration;
 
-            isLittleEnidan = this._configuration.DefaultEndian == Enums.Endian.LITTLE;
+            isMustReverseUnit = (BitConverter.IsLittleEndian == true && this._configuration.DefaultEndian == Enums.Endian.BIG) ||
+                                (BitConverter.IsLittleEndian == false && this._configuration.DefaultEndian == Enums.Endian.LITTLE);
         }
 
         public byte[] Build()


### PR DESCRIPTION
시스템이 빅 엔디안이고 패킷이 빅 엔디안일 경우 오동작 하는 것을 수정합니다.

관련해서 IEnumable.Reverse 대신 Array.Reverse를 사용하여 힙 재할당 없이 속도를 높입니다.